### PR TITLE
Statically link CRT

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "lock"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lock"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Hi,

I've needed to encrypt some files and have found your tool. It is great, fast and easy. The problem that occured to me happened when I tried running this on fresh install of Windows. I got error "VCRUNTIME140.dll missing", it disappeared when I installed Microsoft Visual C++ Redistributable, but still it would be nice if I didn't have to install that first. After some research I have found this [issue](https://github.com/rust-lang/rust/issues/100874). There is also [this](https://www.reddit.com/r/rust/comments/ekts0d/how_to_link_crt_statically_when_building_with_msvc/) thread on Reddit regarding the same issue. Basically Rust by default doesn't statically link to C runtime which is why "VCRUNTIME140.dll" needs to be present in the system. Rust can be manually made to statically link to CRT which should eliminate the error I got at the expense of slightly bigger file size (less than 100 KB). I've added .cargo/config.toml with instruction to statically link CRT when building for Windows x64, as suggested in linked websites. I've also bumped version to 1.0.1 in Cargo.toml, and Cargo.lock. When I compile on my machine, everything works fine, only file size is a little bigger (1012 KB instead of 919 KB before, which shouldn't be problematic IMO). I didn't try it on a fresh windows install to see if it really fixes the problem, but according to linked websites, it should be fixed. If you accept pull request, you would just need to compile and publish new release with these changes.

Regards
